### PR TITLE
Add connection code from st-connection-prpr with minimal scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.8.*",
+    python_requires=">=3.8",
     # Requirements
     install_requires=INSTALL_REQUIRES,
     packages=["st_files_connection"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ VERSION = "0.1.0"  # PEP-440
 NAME = "st_files_connection"
 
 INSTALL_REQUIRES = [
-    "streamlit>=1.22.0",
+    # Update streamlit version after 1.22 release
+    # "streamlit>=1.22",
+    "streamlit",
     "fsspec"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools
+
+VERSION = "0.1.0"  # PEP-440
+
+NAME = "st_files_connection"
+
+INSTALL_REQUIRES = [
+    "streamlit>=1.22.0",
+    "fsspec"
+]
+
+
+setuptools.setup(
+    name=NAME,
+    version=VERSION,
+    description="Streamlit Connection for cloud and remote file storage.",
+    url="https://github.com/streamlit/files-connection",
+    project_urls={
+        "Source Code": "https://github.com/streamlit/files-connection",
+    },
+    author="Snowflake Inc",
+    author_email="hello@streamlit.io",
+    license="Apache License 2.0",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Environment :: Console",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    python_requires=">=3.8.*",
+    # Requirements
+    install_requires=INSTALL_REQUIRES,
+    packages=["st_files_connection"]
+)

--- a/st_files_connection/__init__.py
+++ b/st_files_connection/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st_files_connection.connection import FilesConnection as _FilesConnection
+
+FilesConnection = _FilesConnection

--- a/st_files_connection/__init__.py
+++ b/st_files_connection/__init__.py
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st_files_connection.connection import FilesConnection as _FilesConnection
-
-FilesConnection = _FilesConnection
+from st_files_connection.connection import FilesConnection as FilesConnection

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -1,0 +1,171 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import TextIOWrapper
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator, Optional, Union, overload
+from typing_extensions import Literal
+
+import pandas as pd
+
+from streamlit.connections import ExperimentalBaseConnection
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from fsspec import AbstractFileSystem, filesystem
+    from fsspec.spec import AbstractBufferedFile
+
+
+class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
+
+    def __init__(
+        self, connection_name: str = "default", protocol: str | None = None, **kwargs
+    ) -> None:
+        self.protocol = protocol
+        super().__init__(connection_name, **kwargs)
+
+    def _connect(self, **kwargs) -> "AbstractFileSystem":
+        """
+        Pass a protocol such as "s3", "gcs", or "file"
+        """
+        from fsspec import AbstractFileSystem, filesystem
+        from fsspec.spec import AbstractBufferedFile
+
+        secrets = self._secrets.to_dict()
+        protocol = secrets.pop("protocol", self.protocol)
+
+        if protocol is None:
+            protocol = "file"
+
+        if protocol == "gcs" and secrets:
+            secrets = {"token": secrets}
+
+        if self.protocol is None:
+            self.protocol = protocol
+        
+        secrets.update(kwargs)
+
+        fs = filesystem(protocol, **secrets)
+
+        return fs
+    
+    @property
+    def fs(self) -> "AbstractFileSystem":
+        return self._instance
+
+    def open(
+        self, path: str | Path, mode: str = "rb", *args, **kwargs
+    ) -> Iterator[TextIOWrapper | AbstractBufferedFile]:
+        # Connection name is only passed to make sure that the cache is
+        # connection-specific
+        if "connection_name" in kwargs:
+            kwargs.pop("connection_name")
+
+        return self.fs.open(path, mode, *args, **kwargs)
+
+    @overload
+    def read(
+        self,
+        path: str | Path,
+        input_format: Literal["text"],
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> str:
+        pass
+
+    @overload
+    def read(
+        self,
+        path: str | Path,
+        input_format: Literal["csv"],
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        pass
+
+    @overload
+    def read(
+        self,
+        path: str | Path,
+        input_format: Literal["parquet"],
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        pass
+
+    def read(
+        self,
+        path: str | Path,
+        input_format: str = None,
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ):
+        @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
+        def _read_text(path: str | Path, **kwargs) -> str:
+            if "connection_name" in kwargs:
+                kwargs.pop("connection_name")
+
+            with self.open(path, "rt", **kwargs) as f:
+                return f.read()
+
+        @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
+        def _read_csv(path: str | Path, **kwargs) -> pd.DataFrame:
+            if "connection_name" in kwargs:
+                kwargs.pop("connection_name")
+
+            with self.open(path, "rt") as f:
+                return pd.read_csv(f, **kwargs)
+
+        @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
+        def _read_parquet(path: str | Path, **kwargs) -> pd.DataFrame:
+            if "connection_name" in kwargs:
+                kwargs.pop("connection_name")
+
+            with self.open(path, "rb") as f:
+                return pd.read_parquet(f, **kwargs)
+        
+        if input_format == 'text':
+            return _read_text(path, connection_name=self._connection_name, **kwargs)
+        elif input_format == 'csv':
+            return _read_csv(path, connection_name=self._connection_name, **kwargs)
+        elif input_format == 'parquet':
+            return _read_parquet(path, connection_name=self._connection_name, **kwargs)
+        # TODO: if input_format is None, try to infer it from file extension
+        raise ValueError(f"{input_format} is not a valid value for `input_format=`.")
+
+    def _repr_html_(self) -> str:
+        module_name = getattr(self, "__module__", None)
+        class_name = type(self).__name__
+        if self._connection_name:
+            name = f"`{self._connection_name}` "
+            if len(self._secrets) > 0:
+                cfg = f"""- Configured from `[connections.{self._connection_name}]`
+                """
+            else:
+                cfg = ""
+        else:
+            name = ""
+            cfg = ""
+        md = f"""
+        ---
+        **st.connection {name}built from `{module_name}.{class_name}`**
+        {cfg}
+        - Protocol: `{self.protocol}`
+        - Learn more using `st.help()`
+        ---
+        """
+        return md

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -47,6 +47,8 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
 
         secrets = self._secrets.to_dict()
         protocol = secrets.pop("protocol", self.protocol)
+        if 'protocol' in kwargs:
+            protocol = kwargs.pop('protocol')
 
         if protocol is None:
             protocol = "file"
@@ -148,24 +150,28 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
         raise ValueError(f"{input_format} is not a valid value for `input_format=`.")
 
     def _repr_html_(self) -> str:
+        """Return a human-friendly markdown string describing this connection.
+        This is the string that will be written to the app if a user calls
+        ``st.write(this_connection)``. Subclasses of ExperimentalBaseConnection can freely
+        overwrite this method if desired.
+        Returns
+        -------
+        str
+        """
         module_name = getattr(self, "__module__", None)
         class_name = type(self).__name__
-        if self._connection_name:
-            name = f"`{self._connection_name}` "
-            if len(self._secrets) > 0:
-                cfg = f"""- Configured from `[connections.{self._connection_name}]`
-                """
-            else:
-                cfg = ""
-        else:
-            name = ""
-            cfg = ""
-        md = f"""
-        ---
-        **st.connection {name}built from `{module_name}.{class_name}`**
-        {cfg}
-        - Protocol: `{self.protocol}`
-        - Learn more using `st.help()`
-        ---
-        """
-        return md
+
+        cfg = (
+            f"- Configured from `[connections.{self._connection_name}]`"
+            if len(self._secrets)
+            else ""
+        )
+
+        return f"""
+---
+**st.connection {self._connection_name} built from `{module_name}.{class_name}`**
+{cfg}
+- Protocol: `{self.protocol}`
+- Learn more using `st.help()`
+---
+"""


### PR DESCRIPTION
Copied it over without change from [here](https://github.com/sfc-gh-jcarroll/st-connection-prpr/tree/main/files_connection) with two small edits:
- Deleted the contextmanger import that is now unused
- Added license disclaimer at the top of each file as in streamlit/streamlit

You can see it in action roughly at https://st-connection-preview.streamlit.app/Files

Also did minimal local testing as follows:
```bash
pip install https://core-previews.s3-us-west-2.amazonaws.com/develop-preview/streamlit-1.21.0-py2.py3-none-any.whl
pip install git+https://github.com/streamlit/files-connection@add-connection
```

```python
# streamlit_app.py

import streamlit as st
from st_files_connection import FilesConnection

conn = st.experimental_connection("local", type=FilesConnection)
st.help(conn)
st.write(conn)

license = conn.read('./LICENSE', input_format='text')

license
```