### PR TITLE
Add json and inferred format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ there. You can pass in anything you would pass to an fsspec file system construc
 
 ### read()
 
-`conn.read("path/to/file", input_format="text|csv|parquet", ttl=None) -> pd.DataFrame`
+`conn.read("path/to/file", input_format="text|csv|parquet|json", ttl=None) -> pd.DataFrame`
 
 Specify a path to file and input format. Optionally specify a TTL for caching.
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,25 @@ there. You can pass in anything you would pass to an fsspec file system construc
 
 ### read()
 
-`conn.read("path/to/file", input_format="text|csv|parquet|json" or None, ttl=None) -> pd.DataFrame`
+`conn.read("path/to/file", input_format="text|csv|parquet|json|jsonl" or None, ttl=None) -> pd.DataFrame`
 
 Specify a path to file and input format. Optionally specify a TTL for caching.
 
-Will attempt to infer `input_format` from path suffix if not specified.
+Valid values for `input_format=`:
+
+- `text` returns a string
+- `json` returns a dict or list (depending on the JSON object) - only one object per file is supported
+- `csv`, `parquet`, `jsonl` return a pandas DataFrame
+- `None` will attempt to infer the input format from file extension of `path`
+- Anything else (or unrecognized inferred type) raises a `ValueError`
 
 ```python
 conn = st.experimental_connection("s3", type=FilesConnection)
 df = conn.read(f"my-s3-bucket/path/to/file.parquet", input_format='parquet')
 st.dataframe(df)
 ```
+
+**Note:** We want to add a `format=` argument to specify output format with more options, contributions welcome!
 
 ### open()
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ there. You can pass in anything you would pass to an fsspec file system construc
 
 ### read()
 
-`conn.read("path/to/file", input_format="text|csv|parquet|json", ttl=None) -> pd.DataFrame`
+`conn.read("path/to/file", input_format="text|csv|parquet|json" or None, ttl=None) -> pd.DataFrame`
 
 Specify a path to file and input format. Optionally specify a TTL for caching.
+
+Will attempt to infer `input_format` from path suffix if not specified.
 
 ```python
 conn = st.experimental_connection("s3", type=FilesConnection)

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -181,6 +181,8 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
         if input_format is None:
             # You can construct a Path from a Path so this should work regardless
             input_format = Path(path).suffix.replace('.', '', 1)
+            if input_format == 'txt':
+                input_format = 'text'
 
         if input_format == 'text':
             return _read_text(path, connection_name=self._connection_name, **kwargs)

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -116,7 +116,7 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     def read(
         self,
         path: str | Path,
-        input_format: Union[Literal["csv"], Literal["parquet"], Literal["jsonl"]],
+        input_format: Literal["csv", "parquet", "jsonl"],
         ttl: Optional[Union[float, int, timedelta]] = None,
         **kwargs,
     ) -> pd.DataFrame:
@@ -131,8 +131,9 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     ):
         """Read the file at the specified path, cache the result and return as a pandas DataFrame.
 
-        input_format must be specified - valid values are `text`, `csv`, `parquet`, `json`. Result is
-        cached indefinitely by default, set `ttl = 0` to disable caching.
+        input_format may be specified - valid values are `text`, `csv`, `parquet`, `json`, `jsonl`.
+        If not specified, input_format will be inferred optimistically from path file extension.
+        Result is cached indefinitely by default, set `ttl = 0` to disable caching.
         """
         @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
         def _read_text(path: str | Path, **kwargs) -> str:
@@ -194,7 +195,6 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
             return _read_json(path, connection_name=self._connection_name, **kwargs)
         elif input_format == 'jsonl':
             return _read_jsonl(path, connection_name=self._connection_name, **kwargs)
-        # TODO: if input_format is None, try to infer it from file extension
         raise ValueError(f"{input_format} is not a valid value for `input_format=`.")
 
     def _repr_html_(self) -> str:

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -121,6 +121,16 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     ) -> pd.DataFrame:
         pass
 
+    @overload
+    def read(
+        self,
+        path: str | Path,
+        input_format: Literal["json"],
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        pass
+
     def read(
         self,
         path: str | Path,
@@ -130,7 +140,7 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     ):
         """Read the file at the specified path, cache the result and return as a pandas DataFrame.
 
-        input_format must be specified - valid values are `text`, `csv`, `parquet`. Result is
+        input_format must be specified - valid values are `text`, `csv`, `parquet`, `json`. Result is
         cached indefinitely by default, set `ttl = 0` to disable caching.
         """
         @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
@@ -156,13 +166,26 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
 
             with self.open(path, "rb") as f:
                 return pd.read_parquet(f, **kwargs)
-        
+
+        @cache_data(ttl=ttl, show_spinner="Running `files.read(...)`.")
+        def _read_json(path: str | Path, **kwargs) -> pd.DataFrame:
+            if "connection_name" in kwargs:
+                kwargs.pop("connection_name")
+
+            with self.open(path, "rt") as f:
+                return pd.read_json(f, **kwargs)
+
         if input_format == 'text':
             return _read_text(path, connection_name=self._connection_name, **kwargs)
         elif input_format == 'csv':
             return _read_csv(path, connection_name=self._connection_name, **kwargs)
         elif input_format == 'parquet':
             return _read_parquet(path, connection_name=self._connection_name, **kwargs)
+        elif input_format == 'json':
+            return _read_json(path, connection_name=self._connection_name, **kwargs)
+        elif input_format == 'jsonl':
+            kwargs['lines'] = True
+            return _read_json(path, connection_name=self._connection_name, **kwargs)
         # TODO: if input_format is None, try to infer it from file extension
         raise ValueError(f"{input_format} is not a valid value for `input_format=`.")
 

--- a/st_files_connection/connection.py
+++ b/st_files_connection/connection.py
@@ -106,26 +106,6 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     def read(
         self,
         path: str | Path,
-        input_format: Literal["csv"],
-        ttl: Optional[Union[float, int, timedelta]] = None,
-        **kwargs,
-    ) -> pd.DataFrame:
-        pass
-
-    @overload
-    def read(
-        self,
-        path: str | Path,
-        input_format: Literal["parquet"],
-        ttl: Optional[Union[float, int, timedelta]] = None,
-        **kwargs,
-    ) -> pd.DataFrame:
-        pass
-
-    @overload
-    def read(
-        self,
-        path: str | Path,
         input_format: Literal["json"],
         ttl: Optional[Union[float, int, timedelta]] = None,
         **kwargs,
@@ -136,7 +116,7 @@ class FilesConnection(ExperimentalBaseConnection["AbstractFileSystem"]):
     def read(
         self,
         path: str | Path,
-        input_format: Literal["jsonl"],
+        input_format: Union[Literal["csv"], Literal["parquet"], Literal["jsonl"]],
         ttl: Optional[Union[float, int, timedelta]] = None,
         **kwargs,
     ) -> pd.DataFrame:


### PR DESCRIPTION
- Add support for `input_format='json'` and `input_format='jsonl'` to read() method
- Try to infer input_format from Path.suffix if not specified